### PR TITLE
fix: :ambulance: Slow down get_logs() for public RPCs

### DIFF
--- a/src/tq_oracle/constants.py
+++ b/src/tq_oracle/constants.py
@@ -27,6 +27,9 @@ CCTP_FINALITY_THRESHOLD_SLOW = 2000  # ~15 minutes
 
 CCTP_LOOKBACK_BLOCKS = 80
 CCTP_RATE_LIMITED_LOOKBACK_BLOCKS = 80  # 24 hours
+RPC_RATE_LIMIT_DELAY = (
+    5  # Delay in seconds between RPC calls to avoid rate limits with get_logs()
+)
 HL_BLOCK_TIME = 1  # Hyperliquid block time in seconds
 L1_BLOCK_TIME = 12  # Ethereum L1 block time in seconds
 


### PR DESCRIPTION
This pull request introduces rate limiting to RPC calls in the CCTP bridge check adapter to avoid hitting RPC provider limits, especially when using the default RPC configuration. The main changes include adding a configurable delay between critical RPC calls, refactoring how event logs are queried, and updating relevant function signatures and documentation to support this behavior.

**Rate Limiting Enhancements**
* Added the `RPC_RATE_LIMIT_DELAY` constant to `src/tq_oracle/constants.py` to control the delay between RPC calls.
* Implemented a `_delay` helper method in `CCTPBridgeCheckAdapter` to log and apply the delay when using the default RPC. This method is called before querying event logs when rate limiting is needed.

**Refactoring of Event Log Queries**
* Refactored the `_check_direction` method to perform event log queries sequentially instead of concurrently, inserting delays between calls if using the default RPC. This helps avoid rate limits imposed by some providers.
* Updated the logic in `run_check` to call `_check_direction` separately for each direction (`L1→HL` and `HL→L1`), inserting a delay between calls when using the default RPC. [[1]](diffhunk://#diff-102bb39ebeb92f7d8b75faa789e2a4849c339cf131188322795786848edeae39L157-R163) [[2]](diffhunk://#diff-102bb39ebeb92f7d8b75faa789e2a4849c339cf131188322795786848edeae39L168-R179) [[3]](diffhunk://#diff-102bb39ebeb92f7d8b75faa789e2a4849c339cf131188322795786848edeae39L179-R189)

**Interface and Documentation Updates**
* Added the `using_default_rpc` parameter to the `_check_direction` method and updated its docstring to clarify its purpose. [[1]](diffhunk://#diff-102bb39ebeb92f7d8b75faa789e2a4849c339cf131188322795786848edeae39R228) [[2]](diffhunk://#diff-102bb39ebeb92f7d8b75faa789e2a4849c339cf131188322795786848edeae39R242)

These changes help prevent RPC rate limiting errors and make the adapter more robust when querying event logs from blockchain providers.