### PR TITLE
refactor: improve error handling for missing asset prices in total_assets calculation

### DIFF
--- a/src/tq_oracle/processors/total_assets.py
+++ b/src/tq_oracle/processors/total_assets.py
@@ -8,8 +8,9 @@ def calculate_total_assets(
     aggregated_assets: AggregatedAssets,
     prices: PriceData,
 ) -> int:
-    if aggregated_assets.assets.keys() != prices.prices.keys():
-        raise ValueError("Aggregated assets and relative prices have different keys")
+    missing_assets = aggregated_assets.assets.keys() - prices.prices.keys()
+    if missing_assets:
+        raise ValueError(f"Prices missing for assets: {sorted(missing_assets)}")
 
     return sum(
         aggregated_assets.assets[i] * prices.prices[i] for i in aggregated_assets.assets

--- a/tests/processors/test_total_assets.py
+++ b/tests/processors/test_total_assets.py
@@ -34,7 +34,7 @@ def test_calculate_total_assets_empty_returns_zero():
     assert result == 0
 
 
-def test_calculate_total_assets_mismatched_keys_raises():
+def test_calculate_total_assets_missing_prices_raises():
     aggregated = AggregatedAssets(
         assets={
             "0xA": 1,
@@ -48,5 +48,47 @@ def test_calculate_total_assets_mismatched_keys_raises():
         },
     )
 
-    with pytest.raises(ValueError, match="different keys"):
+    with pytest.raises(ValueError, match=r"Prices missing for assets: \['0xB'\]"):
         calculate_total_assets(aggregated, prices)
+
+
+def test_calculate_total_assets_multiple_missing_prices_raises():
+    aggregated = AggregatedAssets(
+        assets={
+            "0xA": 1,
+            "0xB": 2,
+            "0xC": 3,
+        }
+    )
+    prices = PriceData(
+        base_asset="0xA",
+        prices={
+            "0xA": 10**18,
+        },
+    )
+
+    with pytest.raises(
+        ValueError, match=r"Prices missing for assets: \['0xB', '0xC'\]"
+    ):
+        calculate_total_assets(aggregated, prices)
+
+
+def test_calculate_total_assets_with_extra_prices():
+    aggregated = AggregatedAssets(
+        assets={
+            "0xA": 2,
+            "0xB": 3,
+        }
+    )
+    prices = PriceData(
+        base_asset="0xA",
+        prices={
+            "0xA": 10**18,
+            "0xB": 2 * 10**18,
+            "0xC": 5 * 10**18,
+        },
+    )
+
+    result = calculate_total_assets(aggregated, prices)
+
+    assert result == (2 * 10**18) + (3 * 2 * 10**18)


### PR DESCRIPTION
- Updated the error message to specify which assets are missing prices.
- Renamed the test for mismatched keys to reflect the new error handling.
- Added tests for multiple missing prices and scenarios with extra prices.