### PR TITLE
fix: :bug: check main vault for balances

### DIFF
--- a/tests/adapters/asset_adapters/test_idle_balances.py
+++ b/tests/adapters/asset_adapters/test_idle_balances.py
@@ -167,7 +167,7 @@ async def test_fetch_assets_integration(hl_config):
         "0xdC035D45d973E3EC169d2276DDab16f1e407384F",
     }
 
-    assert len(assets) == 24
+    assert len(assets) == 30
 
     for asset in assets:
         assert isinstance(asset, AssetData)
@@ -192,7 +192,7 @@ async def test_fetch_assets_without_hl_integration(config):
         "0xdC035D45d973E3EC169d2276DDab16f1e407384F",
     }
 
-    assert len(assets) == 24
+    assert len(assets) == 30
 
     for asset in assets:
         assert isinstance(asset, AssetData)


### PR DESCRIPTION
This pull request updates the idle balances fetching logic to include the main vault in addition to all subvaults, ensuring that asset data is collected from every relevant contract. The associated tests have been updated to reflect the increased number of assets returned.

**Idle balances fetching improvements:**

* The `fetch_all_assets` method in `idle_balances.py` now fetches idle balances for both the main vault and all subvaults, rather than just the subvaults. Logging messages and variable names have been updated to reflect this change.

**Test updates:**

* Integration and non-integration tests for idle balances have been updated to expect 30 assets instead of 24, matching the new behavior of including the main vault. (`test_idle_balances.py`) [[1]](diffhunk://#diff-cef73d50f664787b83278e0d151e267f48f5780f992abc7e2584095e2708c430L170-R170) [[2]](diffhunk://#diff-cef73d50f664787b83278e0d151e267f48f5780f992abc7e2584095e2708c430L195-R195)