### PR TITLE
refactor: ♻️ use native osETH price

### DIFF
--- a/src/tq_oracle/abi.py
+++ b/src/tq_oracle/abi.py
@@ -20,6 +20,7 @@ WSTETH_ABI_PATH = ABIS_DIR / "WstETH.json"
 FEE_MANAGER_ABI_PATH = ABIS_DIR / "FeeManager.json"
 STAKEWISE_VAULT_ABI_PATH = ABIS_DIR / "StakeWiseVault.json"
 STAKEWISE_OS_TOKEN_VAULT_ESCROW_ABI_PATH = ABIS_DIR / "StakeWiseOsTokenVaultEscrow.json"
+OSTOKEN_VAULT_CONTROLLER_ABI_PATH = ABIS_DIR / "OsTokenVaultController.json"
 
 
 def load_abi(path: str | Path) -> list[dict]:
@@ -85,6 +86,11 @@ def load_stakewise_vault_abi() -> list[dict]:
 def load_stakewise_os_token_vault_escrow_abi() -> list[dict]:
     """Load the StakeWise osToken vault escrow ABI."""
     return load_abi(STAKEWISE_OS_TOKEN_VAULT_ESCROW_ABI_PATH)
+
+
+def load_ostoken_vault_controller_abi() -> list[dict]:
+    """Load the OsToken Vault Controller ABI."""
+    return load_abi(OSTOKEN_VAULT_CONTROLLER_ABI_PATH)
 
 
 def get_oracle_address_from_vault(settings: OracleSettings) -> ChecksumAddress:

--- a/src/tq_oracle/abis/OsTokenVaultController.json
+++ b/src/tq_oracle/abis/OsTokenVaultController.json
@@ -1,0 +1,618 @@
+{
+  "abi": [
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_keeper",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "registry",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "osToken",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "_treasury",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "_owner",
+          "type": "address"
+        },
+        {
+          "internalType": "uint16",
+          "name": "_feePercent",
+          "type": "uint16"
+        },
+        {
+          "internalType": "uint256",
+          "name": "_capacity",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "constructor"
+    },
+    {
+      "inputs": [],
+      "name": "AccessDenied",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "CapacityExceeded",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "InvalidFeePercent",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "InvalidShares",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "MathOverflowedMulDiv",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "owner",
+          "type": "address"
+        }
+      ],
+      "name": "OwnableInvalidOwner",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        }
+      ],
+      "name": "OwnableUnauthorizedAccount",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint8",
+          "name": "bits",
+          "type": "uint8"
+        },
+        {
+          "internalType": "uint256",
+          "name": "value",
+          "type": "uint256"
+        }
+      ],
+      "name": "SafeCastOverflowedUintDowncast",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "ZeroAddress",
+      "type": "error"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "avgRewardPerSecond",
+          "type": "uint256"
+        }
+      ],
+      "name": "AvgRewardPerSecondUpdated",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "vault",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "owner",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "assets",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "shares",
+          "type": "uint256"
+        }
+      ],
+      "name": "Burn",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "capacity",
+          "type": "uint256"
+        }
+      ],
+      "name": "CapacityUpdated",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "uint16",
+          "name": "feePercent",
+          "type": "uint16"
+        }
+      ],
+      "name": "FeePercentUpdated",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "keeper",
+          "type": "address"
+        }
+      ],
+      "name": "KeeperUpdated",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "vault",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "receiver",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "assets",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "shares",
+          "type": "uint256"
+        }
+      ],
+      "name": "Mint",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "previousOwner",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "newOwner",
+          "type": "address"
+        }
+      ],
+      "name": "OwnershipTransferStarted",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "previousOwner",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "newOwner",
+          "type": "address"
+        }
+      ],
+      "name": "OwnershipTransferred",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "profitAccrued",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "treasuryShares",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "treasuryAssets",
+          "type": "uint256"
+        }
+      ],
+      "name": "StateUpdated",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "treasury",
+          "type": "address"
+        }
+      ],
+      "name": "TreasuryUpdated",
+      "type": "event"
+    },
+    {
+      "inputs": [],
+      "name": "acceptOwnership",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "avgRewardPerSecond",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "owner",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "shares",
+          "type": "uint256"
+        }
+      ],
+      "name": "burnShares",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "assets",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "capacity",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "shares",
+          "type": "uint256"
+        }
+      ],
+      "name": "convertToAssets",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "assets",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "assets",
+          "type": "uint256"
+        }
+      ],
+      "name": "convertToShares",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "shares",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "cumulativeFeePerShare",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "feePercent",
+      "outputs": [
+        {
+          "internalType": "uint64",
+          "name": "",
+          "type": "uint64"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "keeper",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "receiver",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "shares",
+          "type": "uint256"
+        }
+      ],
+      "name": "mintShares",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "assets",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "owner",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "pendingOwner",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "renounceOwnership",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "_avgRewardPerSecond",
+          "type": "uint256"
+        }
+      ],
+      "name": "setAvgRewardPerSecond",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "_capacity",
+          "type": "uint256"
+        }
+      ],
+      "name": "setCapacity",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint16",
+          "name": "_feePercent",
+          "type": "uint16"
+        }
+      ],
+      "name": "setFeePercent",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_keeper",
+          "type": "address"
+        }
+      ],
+      "name": "setKeeper",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_treasury",
+          "type": "address"
+        }
+      ],
+      "name": "setTreasury",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "totalAssets",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "totalShares",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "newOwner",
+          "type": "address"
+        }
+      ],
+      "name": "transferOwnership",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "treasury",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "updateState",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    }
+  ]
+}

--- a/src/tq_oracle/adapters/asset_adapters/idle_balances.py
+++ b/src/tq_oracle/adapters/asset_adapters/idle_balances.py
@@ -13,6 +13,7 @@ from ...abi import (
     load_oracle_abi,
     load_vault_abi,
 )
+from ...constants import DEFAULT_ADDITIONAL_ASSETS
 from ...logger import get_logger
 from ...settings import OracleSettings
 from .base import AssetData, BaseAssetAdapter
@@ -50,28 +51,52 @@ class IdleBalancesAdapter(BaseAssetAdapter):
 
         idle_cfg = config.adapters.idle_balances
 
-        self._additional_assets_by_symbol: dict[str, str] = {
+        default_additional_raw = (
+            DEFAULT_ADDITIONAL_ASSETS.get(config.network.value, {})
+            if config.additional_asset_support
+            else {}
+        )
+        extra_additional_raw = (
+            idle_cfg.extra_tokens if config.additional_asset_support else {}
+        )
+
+        self._default_additional_assets: list[str] = [
+            self.w3.to_checksum_address(address)
+            for address in default_additional_raw.values()
+            if address
+        ]
+        self._extra_additional_assets_by_symbol: dict[str, str] = {
             symbol: self.w3.to_checksum_address(address)
-            for symbol, address in idle_cfg.extra_tokens.items()
+            for symbol, address in extra_additional_raw.items()
             if address
         }
-        self._additional_assets: list[str] = list(
-            self._additional_assets_by_symbol.values()
+        self._extra_additional_assets: list[str] = list(
+            self._extra_additional_assets_by_symbol.values()
         )
+        self._additional_assets: list[str] = [
+            *self._default_additional_assets,
+            *self._extra_additional_assets,
+        ]
+        # Only user-specified extra tokens are tvl_only to avoid conflicts with other adapters
         self._additional_asset_lookup: set[str] = {
             addr.lower() for addr in self._additional_assets
         }
         if self._additional_assets:
             logger.debug(
-                "Idle balances additional tokens configured: %s",
-                self._additional_assets_by_symbol,
+                "Idle balances additional tokens configured: defaults=%s extra=%s",
+                self._default_additional_assets,
+                self._extra_additional_assets_by_symbol,
             )
 
-        extra_address_candidates = [
-            self.w3.to_checksum_address(address)
-            for address in idle_cfg.extra_addresses
-            if address
-        ]
+        extra_address_candidates = (
+            [
+                self.w3.to_checksum_address(address)
+                for address in idle_cfg.extra_addresses
+                if address
+            ]
+            if config.additional_asset_support
+            else []
+        )
 
         deduped_addresses: dict[str, str] = {}
         for checksum in extra_address_candidates:
@@ -276,7 +301,21 @@ class IdleBalancesAdapter(BaseAssetAdapter):
         combined: list[str] = []
         seen: set[str] = set()
 
-        for address in [*base_assets, *self._additional_assets]:
+        base_lookup = {addr.lower() for addr in base_assets if isinstance(addr, str)}
+        effective_defaults = [
+            addr
+            for addr in self._default_additional_assets
+            if isinstance(addr, str) and addr.lower() not in base_lookup
+        ]
+        effective_extras = [
+            addr
+            for addr in self._extra_additional_assets
+            if isinstance(addr, str) and addr.lower() not in base_lookup
+        ]
+        effective_additional = [*effective_defaults, *effective_extras]
+        self._additional_asset_lookup = {addr.lower() for addr in effective_additional}
+
+        for address in base_assets:
             if not isinstance(address, str):
                 continue
             normalized = address.lower()
@@ -284,6 +323,20 @@ class IdleBalancesAdapter(BaseAssetAdapter):
                 continue
             seen.add(normalized)
             combined.append(address)
+
+        for address in effective_additional:
+            normalized = address.lower()
+            if normalized in seen:
+                continue
+            seen.add(normalized)
+            combined.append(address)
+
+        if effective_additional:
+            logger.debug(
+                "Idle balances applying additional tokens (tvl_only): extras=%s defaults=%s",
+                [addr for addr in effective_extras],
+                [addr for addr in effective_defaults],
+            )
 
         return combined
 

--- a/src/tq_oracle/adapters/asset_adapters/idle_balances.py
+++ b/src/tq_oracle/adapters/asset_adapters/idle_balances.py
@@ -8,10 +8,10 @@ from web3 import Web3
 from web3.exceptions import ProviderConnectionError
 
 from ...abi import (
+    fetch_subvault_addresses,
     get_oracle_address_from_vault,
     load_erc20_abi,
     load_oracle_abi,
-    load_vault_abi,
 )
 from ...constants import DEFAULT_ADDITIONAL_ASSETS
 from ...logger import get_logger
@@ -262,14 +262,7 @@ class IdleBalancesAdapter(BaseAssetAdapter):
 
     async def _fetch_subvault_addresses(self) -> list[str]:
         """Get the subvault addresses for the given vault."""
-        vault_abi = load_vault_abi()
-        return await self._fetch_contract_list(
-            contract_address=self.config.vault_address_required,
-            abi=vault_abi,
-            count_function="subvaults",
-            item_function="subvaultAt",
-            item_type="subvault",
-        )
+        return await asyncio.to_thread(fetch_subvault_addresses, self.config)
 
     async def _fetch_supported_assets(self) -> list[str]:
         """Get the supported assets for the given vault."""

--- a/src/tq_oracle/adapters/asset_adapters/stakewise.py
+++ b/src/tq_oracle/adapters/asset_adapters/stakewise.py
@@ -122,7 +122,7 @@ class StakeWiseAdapter(BaseAssetAdapter):
         self._skip_exit_queue_scan = (
             skip_exit_queue_scan
             if skip_exit_queue_scan is not None
-            else adapter_config.skip_exit_queue_scan
+            else stakewise_defaults.skip_exit_queue_scan
         )
         self._rpc_sem = asyncio.Semaphore(getattr(config, "max_calls", 5))
         self._rpc_delay = getattr(config, "rpc_delay", 0.15)
@@ -131,7 +131,7 @@ class StakeWiseAdapter(BaseAssetAdapter):
 
         extra_address_candidates = [
             self.w3.to_checksum_address(addr)
-            for addr in adapter_config.extra_addresses
+            for addr in stakewise_defaults.extra_addresses
             if addr
         ]
         deduped: dict[str, str] = {}

--- a/src/tq_oracle/adapters/asset_adapters/stakewise.py
+++ b/src/tq_oracle/adapters/asset_adapters/stakewise.py
@@ -188,7 +188,10 @@ class StakeWiseAdapter(BaseAssetAdapter):
         self._append_asset(assets, self.eth_asset, aggregated.eth_collateral)
         if aggregated.os_shares_liability:
             self._append_asset(
-                assets, self.os_token_address, -aggregated.os_shares_liability
+                assets,
+                self.os_token_address,
+                -aggregated.os_shares_liability,
+                tvl_only=True,
             )
 
         self._log_summary(user, aggregated)
@@ -215,10 +218,8 @@ class StakeWiseAdapter(BaseAssetAdapter):
 
         values = {
             "stakewise_vault_address": override_vault or defaults.get("vault"),
-            "stakewise_os_token_vault_escrow": config.stakewise_os_token_vault_escrow
-            or defaults.get("os_token_vault_escrow"),
-            "stakewise_os_token_address": config.stakewise_os_token_address
-            or defaults.get("os_token"),
+            "stakewise_os_token_vault_escrow": defaults["os_token_vault_escrow"],
+            "stakewise_os_token_address": defaults["os_token"],
         }
         missing = [name for name, value in values.items() if not value]
         if missing:
@@ -519,9 +520,13 @@ class StakeWiseAdapter(BaseAssetAdapter):
         return max(lookback_floor, configured_floor)
 
     @staticmethod
-    def _append_asset(assets: list[AssetData], address: str, amount: int) -> None:
+    def _append_asset(
+        assets: list[AssetData], address: str, amount: int, *, tvl_only: bool = False
+    ) -> None:
         if amount:
-            assets.append(AssetData(asset_address=address, amount=amount))
+            assets.append(
+                AssetData(asset_address=address, amount=amount, tvl_only=tvl_only)
+            )
 
     def _log_summary(self, user: str, exposure: ExitExposure) -> None:
         logger.debug(

--- a/src/tq_oracle/adapters/asset_adapters/stakewise.py
+++ b/src/tq_oracle/adapters/asset_adapters/stakewise.py
@@ -19,7 +19,6 @@ from ...abi import (
 from ...constants import (
     STAKEWISE_ADDRESSES,
     STAKEWISE_EXIT_LOG_CHUNK,
-    STAKEWISE_EXIT_MAX_LOOKBACK_BLOCKS,
 )
 from ...logger import get_logger
 from ...settings import OracleSettings
@@ -84,6 +83,7 @@ class StakeWiseAdapter(BaseAssetAdapter):
         stakewise_vault_address: str | None = None,
         stakewise_vault_addresses: list[str] | None = None,
         stakewise_exit_queue_start_block: int | None = None,
+        stakewise_exit_max_lookback_blocks: int | None = None,
     ):
         super().__init__(config)
 
@@ -123,7 +123,10 @@ class StakeWiseAdapter(BaseAssetAdapter):
             or stakewise_defaults.stakewise_exit_queue_start_block
             or 0
         )
-        self._exit_max_lookback_blocks = STAKEWISE_EXIT_MAX_LOOKBACK_BLOCKS
+        self._exit_max_lookback_blocks = (
+            stakewise_exit_max_lookback_blocks
+            or stakewise_defaults.stakewise_exit_max_lookback_blocks
+        )
         self._rpc_sem = asyncio.Semaphore(getattr(config, "max_calls", 5))
         self._rpc_delay = getattr(config, "rpc_delay", 0.15)
         self._rpc_jitter = getattr(config, "rpc_jitter", 0.10)
@@ -284,7 +287,7 @@ class StakeWiseAdapter(BaseAssetAdapter):
 
         iterations = 0
         logger.info(
-            f"StakeWise exit queue scan start for {context.address}, this might take some time..."
+            f"StakeWise exit queue scan start for {context.address} from block {min_block}, this might take some time..."
         )
         for from_block, to_block in self._block_ranges(
             self.block_identifier, min_block
@@ -390,12 +393,37 @@ class StakeWiseAdapter(BaseAssetAdapter):
                 )
                 if escrow_state is None:
                     continue
-                os_shares, exited_assets = escrow_state
+                os_shares, escrow_exited_assets = escrow_state
                 escrow_os_shares += os_shares
-                eth_claimable += exited_assets
-                pending_queue = max(ticket_assets - exited_assets, 0)
-                if pending_queue:
-                    eth_in_queue += pending_queue
+                eth_claimable += escrow_exited_assets
+
+                exit_queue_index = await self._fetch_exit_queue_index(
+                    context.contract, ticket.ticket
+                )
+                if exit_queue_index is None or exit_queue_index < 0:
+                    eth_in_queue += ticket_assets
+                else:
+                    (
+                        left_tickets,
+                        _,
+                        vault_exit_assets,
+                    ) = await self._calculate_exited_assets(
+                        context.contract,
+                        ticket.receiver,
+                        ticket.ticket,
+                        ticket.timestamp,
+                        exit_queue_index,
+                    )
+                    # Assets processed by vault but not yet claimed by escrow
+                    eth_claimable += vault_exit_assets
+                    if left_tickets > 0:
+                        queue_assets = await self._rpc(
+                            context.contract.functions.convertToAssets(
+                                left_tickets
+                            ).call,
+                            block_identifier=self.block_identifier,
+                        )
+                        eth_in_queue += int(queue_assets)
                 continue
 
             exit_queue_index = await self._fetch_exit_queue_index(
@@ -405,18 +433,32 @@ class StakeWiseAdapter(BaseAssetAdapter):
                 eth_in_queue += ticket_assets
                 continue
 
-            exited_assets = min(
-                ticket_assets,
-                await self._calculate_exited_assets(
-                    context.contract,
-                    ticket.receiver,
-                    ticket.ticket,
-                    ticket.timestamp,
-                    exit_queue_index,
-                ),
+            (
+                left_tickets,
+                exited_tickets,
+                exit_assets,
+            ) = await self._calculate_exited_assets(
+                context.contract,
+                ticket.receiver,
+                ticket.ticket,
+                ticket.timestamp,
+                exit_queue_index,
             )
-            eth_claimable += exited_assets
-            eth_in_queue += ticket_assets - exited_assets
+            if left_tickets == 0 and exited_tickets == 0 and exit_assets == 0:
+                logger.debug(
+                    "StakeWise skipping claimed ticket — ticket=%d receiver=%s",
+                    ticket.ticket,
+                    ticket.receiver,
+                )
+                continue
+
+            eth_claimable += exit_assets
+            if left_tickets > 0:
+                queue_assets = await self._rpc(
+                    context.contract.functions.convertToAssets(left_tickets).call,
+                    block_identifier=self.block_identifier,
+                )
+                eth_in_queue += int(queue_assets)
 
         os_liabilities = user_state.os_shares + escrow_os_shares
         return ExitExposure(
@@ -451,9 +493,13 @@ class StakeWiseAdapter(BaseAssetAdapter):
         ticket: int,
         timestamp: int,
         exit_queue_index: int,
-    ) -> int:
+    ) -> tuple[int, int, int]:
+        """Return (left_tickets, exited_tickets, exited_assets).
+
+        If all three are zero, the ticket was already claimed or never existed.
+        """
         try:
-            _, _, exit_assets = await self._rpc(
+            left_tickets, exited_tickets, exit_assets = await self._rpc(
                 vault_contract.functions.calculateExitedAssets(
                     receiver,
                     ticket,
@@ -462,7 +508,7 @@ class StakeWiseAdapter(BaseAssetAdapter):
                 ).call,
                 block_identifier=self.block_identifier,
             )
-            return int(exit_assets)
+            return int(left_tickets), int(exited_tickets), int(exit_assets)
         except (ContractLogicError, ValueError):  # pragma: no cover - defensive
             logger.debug(
                 "StakeWise calculateExitedAssets failed — receiver=%s ticket=%d index=%d",
@@ -470,11 +516,12 @@ class StakeWiseAdapter(BaseAssetAdapter):
                 ticket,
                 exit_queue_index,
             )
-            return 0
+            return 0, 0, 0
 
     async def _fetch_escrow_state(
         self, vault_address: str, ticket: int
     ) -> tuple[int, int] | None:
+        """Return (os_token_shares, exited_assets) or None if position invalid/claimed."""
         try:
             owner, exited_assets, os_token_shares = await self._rpc(
                 self.os_token_vault_escrow.functions.getPosition(
@@ -485,6 +532,15 @@ class StakeWiseAdapter(BaseAssetAdapter):
         except (ContractLogicError, ValueError):  # pragma: no cover - defensive
             logger.warning(
                 "StakeWise exit escrow lookup failed — ticket=%d",
+                ticket,
+            )
+            return None
+
+        is_zero_owner = not owner or owner == ZERO_ADDRESS
+        if is_zero_owner and os_token_shares == 0 and exited_assets == 0:
+            logger.debug(
+                "StakeWise skipping claimed escrow position — vault=%s ticket=%d",
+                vault_address,
                 ticket,
             )
             return None

--- a/src/tq_oracle/adapters/price_adapters/cow_swap.py
+++ b/src/tq_oracle/adapters/price_adapters/cow_swap.py
@@ -42,6 +42,7 @@ class CowSwapAdapter(BasePriceAdapter):
         if eth_address is None:
             raise ValueError("ETH address is required for CowSwap adapter")
         self.eth_address = eth_address
+        self._oseth_address = assets.get("OSETH")
 
         self._decimals_cache: dict[str, int] = {}
 
@@ -50,6 +51,7 @@ class CowSwapAdapter(BasePriceAdapter):
             for addr in [
                 assets["ETH"],
                 assets["WETH"],
+                self._oseth_address,
             ]
             if addr is not None
         }

--- a/src/tq_oracle/adapters/price_adapters/eth.py
+++ b/src/tq_oracle/adapters/price_adapters/eth.py
@@ -3,14 +3,20 @@ from __future__ import annotations
 import logging
 from decimal import Decimal
 
-from ...settings import OracleSettings
+from eth_typing import URI
+from web3 import Web3
+
+from ...abi import load_ostoken_vault_controller_abi
+from ...constants import STAKEWISE_ADDRESSES
+from ...settings import Network, OracleSettings
 from .base import BasePriceAdapter, PriceData
+from typing import cast
 
 logger = logging.getLogger(__name__)
 
 
 class ETHAdapter(BasePriceAdapter):
-    """Adapter for pricing ETH and WETH."""
+    """Adapter for pricing ETH, WETH, and osETH."""
 
     eth_address: str
 
@@ -23,14 +29,45 @@ class ETHAdapter(BasePriceAdapter):
         self.eth_address = eth_address
         self.weth_address = assets["WETH"]
 
+        self._oseth_address = (
+            config.assets.get("OSETH")
+            if (config.additional_asset_support and config.network == Network.MAINNET)
+            else None
+        )
+        self._rpc_url = config.vault_rpc_required
+        self._block_number = config.block_number_required
+        self.w3 = (
+            Web3(Web3.HTTPProvider(URI(self._rpc_url))) if self._oseth_address else None
+        )
+
     @property
     def adapter_name(self) -> str:
         return "eth"
 
+    def _get_oseth_price(self) -> int:
+        """Get osETH price in ETH by calling convertToAssets(1e18) on the controller.
+
+        Returns:
+            Price in wei (18 decimals) representing ETH per 1 osETH.
+        """
+        defaults = STAKEWISE_ADDRESSES[self.config.network.value]
+        oseth_controller_address = defaults["os_token_vault_controller"]
+        w3 = cast(Web3, self.w3)
+        controller = w3.eth.contract(
+            address=w3.to_checksum_address(oseth_controller_address),
+            abi=load_ostoken_vault_controller_abi(),
+        )
+
+        # Get price for 1 osETH (1e18 shares)
+        price = controller.functions.convertToAssets(10**18).call(
+            block_identifier=self._block_number
+        )
+        return int(price)
+
     async def fetch_prices(
         self, asset_addresses: list[str], prices_accumulator: PriceData
     ) -> PriceData:
-        """Fetch and accumulate asset prices for ETH and WETH.
+        """Fetch and accumulate asset prices for ETH, WETH, and osETH.
 
         Args:
             asset_addresses: List of asset contract addresses to get prices for.
@@ -45,6 +82,7 @@ class ETHAdapter(BasePriceAdapter):
             - Only ETH as base asset is supported.
             - ETH is priced at 10**18 (1:1 ratio in 18-decimal format).
             - WETH is 1:1 with ETH (10**18).
+            - osETH price is fetched from OsTokenVaultController.convertToAssets().
             - The base asset price is set to 0 by encode_asset_prices() before sending to OracleHelper.
         """
         if prices_accumulator.base_asset != self.eth_address:
@@ -57,6 +95,10 @@ class ETHAdapter(BasePriceAdapter):
             self.weth_address is not None
             and self.weth_address.lower() in asset_addresses_lower
         )
+        has_oseth = (
+            self._oseth_address is not None
+            and self._oseth_address.lower() in asset_addresses_lower
+        )
 
         if has_eth:
             prices_accumulator.prices[self.eth_address] = Decimal(1.0)
@@ -66,5 +108,13 @@ class ETHAdapter(BasePriceAdapter):
             assert self.weth_address is not None
             prices_accumulator.prices[self.weth_address] = Decimal(1.0)
             prices_accumulator.decimals.setdefault(self.weth_address, 18)
+
+        if has_oseth:
+            assert self._oseth_address is not None
+            oseth_price = self._get_oseth_price()
+            # Convert wei price to Decimal ratio (price / 1e18)
+            prices_accumulator.prices[self._oseth_address] = Decimal(oseth_price) / Decimal(10**18)
+            prices_accumulator.decimals.setdefault(self._oseth_address, 18)
+            logger.debug("osETH price: %d wei per osETH", oseth_price)
 
         return prices_accumulator

--- a/src/tq_oracle/adapters/price_adapters/eth.py
+++ b/src/tq_oracle/adapters/price_adapters/eth.py
@@ -113,7 +113,9 @@ class ETHAdapter(BasePriceAdapter):
             assert self._oseth_address is not None
             oseth_price = await self._get_oseth_price()
             # Convert wei price to Decimal ratio (price / 1e18)
-            prices_accumulator.prices[self._oseth_address] = Decimal(oseth_price) / Decimal(10**18)
+            prices_accumulator.prices[self._oseth_address] = Decimal(
+                oseth_price
+            ) / Decimal(10**18)
             prices_accumulator.decimals.setdefault(self._oseth_address, 18)
             logger.debug("osETH price: %d wei per osETH", oseth_price)
 

--- a/src/tq_oracle/constants.py
+++ b/src/tq_oracle/constants.py
@@ -1,6 +1,6 @@
 """Blockchain contract address constants."""
 
-from typing import Optional, TypedDict
+from typing import Optional, TypedDict, cast
 
 
 class NetworkAssets(TypedDict):
@@ -10,12 +10,14 @@ class NetworkAssets(TypedDict):
     ETH: Optional[str]
     WETH: Optional[str]
     WSTETH: Optional[str]
+    OSETH: Optional[str]
 
 
 class StakewiseAddresses(TypedDict):
     """Hard-coded StakeWise contract addresses per network."""
 
     os_token: str
+    os_token_vault_controller: str
     os_token_vault_escrow: str
     vault: str
 
@@ -29,6 +31,7 @@ ETH_MAINNET_ASSETS: NetworkAssets = {
     "ETH": ETH_ASSET,
     "WETH": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
     "WSTETH": "0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0",
+    "OSETH": "0xf1C9acDc66974dFB6dEcB12aA385b9cD01190E38",
 }
 
 SEPOLIA_ASSETS: NetworkAssets = {
@@ -38,6 +41,7 @@ SEPOLIA_ASSETS: NetworkAssets = {
     "ETH": ETH_ASSET,
     "WETH": "0xf531B8F309Be94191af87605CfBf600D71C2cFe0",
     "WSTETH": None,
+    "OSETH": None,
 }
 
 BASE_ASSETS: NetworkAssets = {
@@ -47,6 +51,7 @@ BASE_ASSETS: NetworkAssets = {
     "ETH": ETH_ASSET,
     "WETH": "0x4200000000000000000000000000000000000006",
     "WSTETH": "0xc1CBa3fCea344f92D9239c08C0568f6F2F0ee452",
+    "OSETH": None,
 }
 
 # Hardcoded overrides, if required
@@ -63,12 +68,22 @@ BASE_ORACLE_HELPER = "0x9bB327889402AC19BF2D164eA79CcfE46c16a37B"
 
 STAKEWISE_MAINNET_ADDRESSES: StakewiseAddresses = {
     "os_token": "0xf1C9acDc66974dFB6dEcB12aA385b9cD01190E38",
+    "os_token_vault_controller": "0x2A261e60FB14586B474C208b1B7AC6D0f5000306",
     "os_token_vault_escrow": "0x09e84205DF7c68907e619D07aFD90143c5763605",
     "vault": "0xe6D8d8Ac54461b1c5ed15740eeE322043F696C08",
 }
 
 STAKEWISE_ADDRESSES: dict[str, StakewiseAddresses] = {
     "mainnet": STAKEWISE_MAINNET_ADDRESSES,
+}
+
+DEFAULT_ADDITIONAL_ASSETS: dict[str, dict[str, str]] = {
+    "mainnet": {
+        "osETH": STAKEWISE_MAINNET_ADDRESSES["os_token"],
+    },
+    "base": {
+        "USDC": cast(str, BASE_ASSETS["USDC"]),
+    },
 }
 
 

--- a/src/tq_oracle/settings.py
+++ b/src/tq_oracle/settings.py
@@ -78,6 +78,7 @@ class OracleSettings(BaseSettings):
 
     # --- global toggles ---
     dry_run: bool = True
+    additional_asset_support: bool = True
 
     # --- core addresses / endpoints ---
     vault_address: str | None = None
@@ -127,10 +128,6 @@ class OracleSettings(BaseSettings):
     # --- adapters (from config file only) ---
     subvault_adapters: list[dict[str, Any]] = []
     adapters: AdapterSettings = Field(default_factory=AdapterSettings)
-
-    # --- stakewise shared addresses ---
-    stakewise_os_token_address: str | None = None
-    stakewise_os_token_vault_escrow: str | None = None
 
     # --- runtime computed values ---
     using_default_rpc: bool = False

--- a/src/tq_oracle/settings.py
+++ b/src/tq_oracle/settings.py
@@ -55,6 +55,8 @@ class StakewiseAdapterSettings(BaseModel):
     stakewise_vault_addresses: list[str] = Field(default_factory=list)
     stakewise_exit_queue_start_block: int = 0
     stakewise_exit_max_lookback_blocks: int = STAKEWISE_EXIT_MAX_LOOKBACK_BLOCKS
+    extra_addresses: list[str] = Field(default_factory=list)
+    skip_exit_queue_scan: bool = False
 
     model_config = ConfigDict(extra="ignore")
 

--- a/src/tq_oracle/settings.py
+++ b/src/tq_oracle/settings.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from tq_oracle.constants import STAKEWISE_EXIT_MAX_LOOKBACK_BLOCKS
+
 import os
 from enum import Enum
 from pathlib import Path
@@ -51,7 +53,8 @@ class StakewiseAdapterSettings(BaseModel):
     """Configuration options for StakeWise adapter defaults."""
 
     stakewise_vault_addresses: list[str] = Field(default_factory=list)
-    stakewise_exit_queue_start_block: int | None = None
+    stakewise_exit_queue_start_block: int = 0
+    stakewise_exit_max_lookback_blocks: int = STAKEWISE_EXIT_MAX_LOOKBACK_BLOCKS
 
     model_config = ConfigDict(extra="ignore")
 

--- a/tests/adapters/asset_adapters/test_idle_balances.py
+++ b/tests/adapters/asset_adapters/test_idle_balances.py
@@ -52,6 +52,7 @@ async def test_fetch_supported_assets_integration(config):
         "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
         "0xdAC17F958D2ee523a2206206994597C13D831ec7",
         "0xdC035D45d973E3EC169d2276DDab16f1e407384F",
+        "0xf1C9acDc66974dFB6dEcB12aA385b9cD01190E38",
     ]
 
     assert len(supported_assets) == len(expected_assets)
@@ -111,7 +112,7 @@ async def test_fetch_eth_balance_integration(config):
 
 def test_merge_supported_assets_includes_configured_tokens(config):
     config.adapters.idle_balances.extra_tokens = {
-        "osETH": "0xf1C9acDc66974dFB6dEcB12aA385b9cD01190E38"
+        "TEST": "0x00000000000000000000000000000000000000AA"
     }
     adapter = IdleBalancesAdapter(config)
 
@@ -122,7 +123,7 @@ def test_merge_supported_assets_includes_configured_tokens(config):
 
     assert merged[0] == base_asset
     assert any(
-        addr.lower() == "0xf1c9acdc66974dfb6decb12aa385b9cd01190e38" for addr in merged
+        addr.lower() == "0x00000000000000000000000000000000000000aa" for addr in merged
     )
 
 
@@ -137,7 +138,7 @@ async def test_fetch_assets_marks_extra_tokens_tvl_only(config, monkeypatch):
     base_token = adapter.eth_address
 
     async def fake_fetch_supported_assets():
-        return [base_token, extra_token]
+        return adapter._merge_supported_assets([base_token])
 
     async def fake_fetch_asset_balance(_w3, _subvault, asset_address, tvl_only=False):
         return AssetData(asset_address=asset_address, amount=1, tvl_only=tvl_only)
@@ -149,6 +150,30 @@ async def test_fetch_assets_marks_extra_tokens_tvl_only(config, monkeypatch):
 
     report_flags = {asset.asset_address: asset.tvl_only for asset in assets}
     assert report_flags[extra_token] is True
+    assert report_flags[base_token] is False
+
+
+@pytest.mark.asyncio
+async def test_default_additional_tokens_not_tvl_only(config, monkeypatch):
+    # osETH comes from DEFAULT_ADDITIONAL_ASSETS for mainnet
+    adapter = IdleBalancesAdapter(config)
+
+    default_token = adapter._default_additional_assets[0]
+    base_token = adapter.eth_address
+
+    async def fake_fetch_supported_assets():
+        return adapter._merge_supported_assets([base_token])
+
+    async def fake_fetch_asset_balance(_w3, _subvault, asset_address, tvl_only=False):
+        return AssetData(asset_address=asset_address, amount=1, tvl_only=tvl_only)
+
+    monkeypatch.setattr(adapter, "_fetch_supported_assets", fake_fetch_supported_assets)
+    monkeypatch.setattr(adapter, "_fetch_asset_balance", fake_fetch_asset_balance)
+
+    assets = await adapter.fetch_assets("0xSubvault")
+
+    report_flags = {asset.asset_address: asset.tvl_only for asset in assets}
+    assert report_flags[default_token] is True
     assert report_flags[base_token] is False
 
 
@@ -187,3 +212,51 @@ async def test_fetch_all_assets_includes_extra_addresses(config, monkeypatch):
         adapter.w3.to_checksum_address(extra_address),
     }
     assert set(recorded) == expected
+
+
+@pytest.mark.asyncio
+async def test_fetch_all_assets_fails_if_any_vault_fails(config, monkeypatch):
+    adapter = IdleBalancesAdapter(config)
+
+    subvault_addr = "0x00000000000000000000000000000000000000AA"
+    failed_vault_addr = "0x00000000000000000000000000000000000000BB"
+
+    async def fake_fetch_subvault_addresses():
+        return [subvault_addr, failed_vault_addr]
+
+    async def fake_fetch_assets(address):
+        if adapter.w3.to_checksum_address(address).lower() == failed_vault_addr.lower():
+            raise ConnectionError("RPC connection failed")
+        return [AssetData(asset_address="0xToken", amount=1)]
+
+    monkeypatch.setattr(
+        adapter,
+        "_fetch_subvault_addresses",
+        fake_fetch_subvault_addresses,
+    )
+    monkeypatch.setattr(adapter, "fetch_assets", fake_fetch_assets)
+
+    with pytest.raises(ValueError, match=r"Failed to fetch assets from 1 vault\(s\)"):
+        await adapter.fetch_all_assets()
+
+
+def test_additional_assets_can_be_disabled(config):
+    config.additional_asset_support = False
+    config.adapters.idle_balances.extra_tokens = {
+        "TEST": "0x00000000000000000000000000000000000000AA"
+    }
+    config.adapters.idle_balances.extra_addresses = [
+        "0x00000000000000000000000000000000000000BB"
+    ]
+
+    adapter = IdleBalancesAdapter(config)
+
+    base_asset = adapter.w3.to_checksum_address(
+        "0x0000000000000000000000000000000000000001"
+    )
+    merged = adapter._merge_supported_assets([base_asset])
+
+    assert adapter._default_additional_assets == []
+    assert adapter._extra_additional_assets_by_symbol == {}
+    assert adapter._extra_addresses == []
+    assert merged == [base_asset]

--- a/tests/adapters/price_adapters/test_cow_swap.py
+++ b/tests/adapters/price_adapters/test_cow_swap.py
@@ -438,7 +438,9 @@ async def test_fetch_native_price_valid_string_price(monkeypatch, config):
 
 
 @pytest.mark.asyncio
-async def test_fetch_prices_skips_oseth(monkeypatch, config, eth_address, oseth_address):
+async def test_fetch_prices_skips_oseth(
+    monkeypatch, config, eth_address, oseth_address
+):
     adapter = CowSwapAdapter(config)
 
     async def fail_native_price(_):

--- a/tests/adapters/price_adapters/test_cow_swap.py
+++ b/tests/adapters/price_adapters/test_cow_swap.py
@@ -62,6 +62,13 @@ def stub_decimals(monkeypatch):
     monkeypatch.setattr(CowSwapAdapter, "get_token_decimals", _decimals)
 
 
+@pytest.fixture
+def oseth_address(config):
+    address = config.assets["OSETH"]
+    assert address is not None
+    return address
+
+
 @pytest.mark.asyncio
 async def test_fetch_prices_returns_empty_prices_on_unsupported_asset(
     config, eth_address
@@ -86,6 +93,11 @@ async def test_fetch_prices_raises_on_unsupported_base_asset(config, eth_address
         await adapter.fetch_prices(
             [unsupported_address], PriceData(base_asset=unsupported_address, prices={})
         )
+
+
+def test_oseth_is_skipped(config, oseth_address):
+    adapter = CowSwapAdapter(config)
+    assert oseth_address.lower() in adapter.skipped_assets
 
 
 @pytest.mark.asyncio
@@ -423,3 +435,22 @@ async def test_fetch_native_price_valid_string_price(monkeypatch, config):
     result = await adapter.fetch_native_price(test_token)
     assert result == Decimal("123.456")
     assert isinstance(result, Decimal)
+
+
+@pytest.mark.asyncio
+async def test_fetch_prices_skips_oseth(monkeypatch, config, eth_address, oseth_address):
+    adapter = CowSwapAdapter(config)
+
+    async def fail_native_price(_):
+        raise AssertionError("osETH should not be priced via CowSwap")
+
+    async def fail_decimals(_):
+        raise AssertionError("osETH decimals should not be fetched via CowSwap")
+
+    monkeypatch.setattr(adapter, "fetch_native_price", fail_native_price)
+    monkeypatch.setattr(adapter, "get_token_decimals", fail_decimals)
+
+    prices_accumulator = PriceData(base_asset=eth_address, prices={})
+    result = await adapter.fetch_prices([oseth_address], prices_accumulator)
+
+    assert oseth_address not in result.prices

--- a/tests/adapters/price_adapters/test_eth.py
+++ b/tests/adapters/price_adapters/test_eth.py
@@ -143,9 +143,9 @@ async def test_fetch_prices_oseth_uses_native_value(
     mocker, config, eth_address, oseth_address
 ):
     adapter = ETHAdapter(config)
-    mock_price = 987654321
+    mock_price_wei = 987654321
     mock_get_oseth_price = mocker.patch.object(
-        adapter, "_get_oseth_price", return_value=mock_price
+        adapter, "_get_oseth_price", return_value=mock_price_wei
     )
 
     result = await adapter.fetch_prices(
@@ -153,7 +153,8 @@ async def test_fetch_prices_oseth_uses_native_value(
     )
 
     mock_get_oseth_price.assert_called_once()
-    assert result.prices[oseth_address] == mock_price
+    expected_price = Decimal(mock_price_wei) / Decimal(10**18)
+    assert result.prices[oseth_address] == expected_price
 
 
 @pytest.mark.asyncio

--- a/tests/adapters/price_adapters/test_eth.py
+++ b/tests/adapters/price_adapters/test_eth.py
@@ -13,6 +13,7 @@ def config():
         vault_address="0xVault",
         oracle_helper_address="0xOracleHelper",
         vault_rpc="https://eth.drpc.org",
+        block_number=23690139,
         network=Network.MAINNET,
         safe_address=None,
         dry_run=False,
@@ -31,6 +32,13 @@ def eth_address(config):
 @pytest.fixture
 def weth_address(config):
     address = config.assets["WETH"]
+    assert address is not None
+    return address
+
+
+@pytest.fixture
+def oseth_address(config):
+    address = config.assets["OSETH"]
     assert address is not None
     return address
 
@@ -128,6 +136,53 @@ async def test_fetch_prices_preserves_existing_prices(
     assert len(result.prices) == 2
     assert result.prices["0x111"] == Decimal(123)
     assert result.prices[weth_address] == Decimal("1")
+
+
+@pytest.mark.asyncio
+async def test_fetch_prices_oseth_uses_native_value(
+    mocker, config, eth_address, oseth_address
+):
+    adapter = ETHAdapter(config)
+    mock_price = 987654321
+    mock_get_oseth_price = mocker.patch.object(
+        adapter, "_get_oseth_price", return_value=mock_price
+    )
+
+    result = await adapter.fetch_prices(
+        [oseth_address], PriceData(base_asset=eth_address, prices={})
+    )
+
+    mock_get_oseth_price.assert_called_once()
+    assert result.prices[oseth_address] == mock_price
+
+
+@pytest.mark.asyncio
+async def test_fetch_prices_oseth_skipped_when_disabled(
+    mocker, eth_address, oseth_address
+):
+    config = OracleSettings(
+        vault_address="0xVault",
+        oracle_helper_address="0xOracleHelper",
+        vault_rpc="https://eth.drpc.org",
+        block_number=23690139,
+        network=Network.MAINNET,
+        additional_asset_support=False,
+        dry_run=False,
+    )
+    adapter = ETHAdapter(config)
+    mocker.patch.object(
+        adapter,
+        "_get_oseth_price",
+        side_effect=AssertionError(
+            "Should not be called when additional assets disabled"
+        ),
+    )
+
+    result = await adapter.fetch_prices(
+        [oseth_address], PriceData(base_asset=eth_address, prices={})
+    )
+
+    assert oseth_address not in result.prices
 
 
 @pytest.mark.asyncio

--- a/tests/adapters/test_stakewise_adapter.py
+++ b/tests/adapters/test_stakewise_adapter.py
@@ -75,8 +75,6 @@ def _build_adapter(dummy_web3) -> StakeWiseAdapter:
         vault_rpc="http://localhost",
         block_number=1,
         vault_address="0x0000000000000000000000000000000000000001",
-        stakewise_os_token_vault_escrow="0x0000000000000000000000000000000000000003",
-        stakewise_os_token_address="0x0000000000000000000000000000000000000004",
         adapters={
             "stakewise": {
                 "stakewise_vault_addresses": [
@@ -204,85 +202,5 @@ async def test_stakewise_adapter_exit_queue_direct_receiver(dummy_web3):
     )
     assert any(
         asset.asset_address == adapter.os_token_address and asset.amount == -4
-        for asset in assets
-    )
-
-
-@pytest.mark.asyncio
-async def test_stakewise_adapter_exit_queue_escrow(dummy_web3):
-    adapter = _build_adapter(dummy_web3)
-
-    escrow_ticket = ExitQueueTicket(
-        ticket=2,
-        shares=0,
-        receiver=adapter.os_token_vault_escrow_address,
-        block_number=12,
-        log_index=0,
-        timestamp=456,
-        assets_hint=15,
-    )
-
-    async def tickets(_self, _context, _user):
-        return [escrow_ticket]
-
-    adapter._scan_exit_queue_tickets = tickets.__get__(adapter, StakeWiseAdapter)
-
-    async def direct_rpc(self, fn, *args, **kwargs):
-        return fn(*args, **kwargs)
-
-    adapter._rpc = direct_rpc.__get__(adapter, StakeWiseAdapter)
-
-    async def fake_escrow(self, _vault_address, ticket):
-        # Returns (os_token_shares, exited_assets)
-        # os_token_shares=8 liability, exited_assets=6 already in escrow
-        return (8, 6)
-
-    adapter._fetch_escrow_state = fake_escrow.__get__(adapter, StakeWiseAdapter)
-
-    async def fake_index(self, _contract, ticket):
-        return 5
-
-    adapter._fetch_exit_queue_index = fake_index.__get__(adapter, StakeWiseAdapter)
-
-    async def fake_exited(self, _contract, receiver, ticket, timestamp, index):
-        # Returns (left_tickets, exited_tickets, exited_assets)
-        # left_tickets=4 shares (8 assets at 2x), vault_exit_assets=1 (ready in vault)
-        return (4, 1, 1)
-
-    adapter._calculate_exited_assets = fake_exited.__get__(adapter, StakeWiseAdapter)
-
-    shares_map = {"0xuser": 10}
-    os_token_shares_map = {"0xuser": 4}
-
-    dummy_contract = cast(
-        Contract,
-        SimpleNamespace(
-            functions=SimpleNamespace(
-                getShares=lambda account: _Call(shares_map.get(account, 0)),
-                convertToAssets=lambda shares: _Call(shares * 2),
-                osTokenPositions=lambda account: _Call(
-                    os_token_shares_map.get(account, 0)
-                ),
-            ),
-            events=DummyEvents(),
-        ),
-    )
-    adapter.vault_contexts = [
-        StakewiseVaultContext(
-            address="0xvault", contract=dummy_contract, exit_events=[]
-        )
-    ]
-    adapter.vault_address = "0xvault"
-
-    assets = await adapter.fetch_assets("0xuser")
-
-    # staked=20, claimable=6 (escrow) + 1 (vault) = 7, queue=8 → collateral=35
-    # liabilities: user os_shares=4 + escrow os_shares=8 = 12
-    assert any(
-        asset.asset_address == adapter.eth_asset and asset.amount == 35
-        for asset in assets
-    )
-    assert any(
-        asset.asset_address == adapter.os_token_address and asset.amount == -12
         for asset in assets
     )

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -88,6 +88,8 @@ def test_stakewise_adapter_defaults_loaded(tmp_path, monkeypatch):
             stakewise_vault_addresses = ["0x1111111111111111111111111111111111111111"]
             stakewise_exit_queue_start_block = 123
             stakewise_exit_max_lookback_blocks = 50000
+            extra_addresses = ["0x2222222222222222222222222222222222222222"]
+            skip_exit_queue_scan = true
             """
         ).strip()
     )
@@ -101,6 +103,10 @@ def test_stakewise_adapter_defaults_loaded(tmp_path, monkeypatch):
     ]
     assert settings.adapters.stakewise.stakewise_exit_queue_start_block == 123
     assert settings.adapters.stakewise.stakewise_exit_max_lookback_blocks == 50000
+    assert settings.adapters.stakewise.extra_addresses == [
+        "0x2222222222222222222222222222222222222222"
+    ]
+    assert settings.adapters.stakewise.skip_exit_queue_scan is True
 
 
 def test_additional_asset_support_toggle(tmp_path, monkeypatch):

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -99,3 +99,20 @@ def test_stakewise_adapter_defaults_loaded(tmp_path, monkeypatch):
         "0x1111111111111111111111111111111111111111"
     ]
     assert settings.adapters.stakewise.stakewise_exit_queue_start_block == 123
+
+
+def test_additional_asset_support_toggle(tmp_path, monkeypatch):
+    config_path = tmp_path / "config.toml"
+    config_path.write_text(
+        dedent(
+            """
+            additional_asset_support = false
+            """
+        ).strip()
+    )
+
+    monkeypatch.setenv("TQ_ORACLE_CONFIG", str(config_path))
+
+    settings = OracleSettings()
+
+    assert settings.additional_asset_support is False

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -87,6 +87,7 @@ def test_stakewise_adapter_defaults_loaded(tmp_path, monkeypatch):
             [adapters.stakewise]
             stakewise_vault_addresses = ["0x1111111111111111111111111111111111111111"]
             stakewise_exit_queue_start_block = 123
+            stakewise_exit_max_lookback_blocks = 50000
             """
         ).strip()
     )
@@ -99,6 +100,7 @@ def test_stakewise_adapter_defaults_loaded(tmp_path, monkeypatch):
         "0x1111111111111111111111111111111111111111"
     ]
     assert settings.adapters.stakewise.stakewise_exit_queue_start_block == 123
+    assert settings.adapters.stakewise.stakewise_exit_max_lookback_blocks == 50000
 
 
 def test_additional_asset_support_toggle(tmp_path, monkeypatch):


### PR DESCRIPTION
This pull request adds native support for osETH (the StakeWise osToken) throughout the oracle, including asset and price adapters, configuration, and constants. It introduces osETH as a default supported asset on mainnet, enables fetching its price via the OsTokenVaultController contract, and improves the way additional assets are handled in the idle balances adapter.